### PR TITLE
Fix detectAnnotatedDataType to handle pointer types

### DIFF
--- a/client.go
+++ b/client.go
@@ -552,20 +552,22 @@ func buildAnnotatedBody(data any) (io.Reader, string, error) {
 // detectAnnotatedDataType takes data of any type and returns the data format as a string (either
 // "json" or "xml") by checking the struct tags.
 func detectAnnotatedDataType(data any) string {
-	value := reflect.ValueOf(data)
-
-	for i := range value.Type().NumField() {
-		field := value.Type().Field(i)
-
+	t := reflect.TypeOf(data)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return ""
+	}
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
 		if _, ok := field.Tag.Lookup("json"); ok {
 			return "json"
 		}
-
 		if _, ok := field.Tag.Lookup("xml"); ok {
 			return "xml"
 		}
 	}
-
 	return ""
 }
 


### PR DESCRIPTION
The function now dereferences pointers to access the underlying struct type, ensuring it correctly detects JSON or XML tags even when a pointer is passed. Added check for non-struct types to return early if invalid. This resolves the issue where passing a pointer (&MyStruct{}) returned an empty string instead of "json".