### PR TITLE
feat: add TLSConfig option on surf client builder

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -2,6 +2,7 @@ package surf
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -179,6 +180,11 @@ func (b *Builder) DNSOverTLS() *DNSOverTLS { return &DNSOverTLS{builder: b} }
 // Timeout sets the timeout duration for the client.
 func (b *Builder) Timeout(timeout time.Duration) *Builder {
 	return b.addCliMW(func(client *Client) error { return timeoutMW(client, timeout) }, 0)
+}
+
+// TLSConfig sets a custom TLS configuration for the client.
+func (b *Builder) TLSConfig(config *tls.Config) *Builder {
+	return b.addCliMW(func(client *Client) error { return tlsConfigMW(client, config) }, 0)
 }
 
 // InterfaceAddr sets the local network interface for outbound connections.

--- a/middleware_client.go
+++ b/middleware_client.go
@@ -154,6 +154,16 @@ func timeoutMW(client *Client, timeout time.Duration) error {
 	return nil
 }
 
+// tlsConfigMW configures a custom TLS configuration for the client.
+// This allows setting custom certificates, cipher suites, TLS versions, and other TLS parameters.
+func tlsConfigMW(client *Client, config *tls.Config) error {
+	if config == nil {
+		return errors.New("TLS config is nil")
+	}
+	client.tlsConfig = config
+	return nil
+}
+
 // redirectPolicyMW configures the client's HTTP redirect handling behavior.
 // Sets up redirect policies including maximum redirect count, host-only redirects,
 // header forwarding on redirects, and custom redirect functions.


### PR DESCRIPTION
To capture Surf requests using Wireshark, I need to add the TLS Client option.