### PR TITLE
Ensure Content-Length is preserved by checking Len() before wrapping with io.NopCloser

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,7 +222,7 @@ func (req *Request) Body(data any) *Request {
 		return req
 	}
 
-	// if Reader implements extra Len() method then set-content length explicitly before wrapping with NopCloser
+	// if Reader implements extra Len() method then set content length explicitly before wrapping with NopCloser
 	lenReader, hasLen := body.(interface{ Len() int })
 	if hasLen {
 		req.request.ContentLength = int64(lenReader.Len())


### PR DESCRIPTION
Our current implementation wraps the request body with io.NopCloser too early. This masks the underlying Len() method, causing the Go HTTP client to lose track of the body size. As a result, it defaults to Transfer-Encoding: chunked and omits the Content-Length header.
This PR fixes the issue by explicitly capturing the content length from the reader (if available) before it is wrapped, ensuring standard HTTP behavior.